### PR TITLE
Add real stage-based SSE streaming to the analysis pipeline

### DIFF
--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -3,11 +3,13 @@ Analysis Router - Gateway endpoints that call Analysis Service
 
 This router handles:
 - /api/analyze (authenticated) - Full analysis with history
+- /api/analyze/stream (authenticated) - Stage-based SSE streaming analysis
 - /api/analyze-public (public) - Analysis without history
 - /api/analysis-service/health - Health proxy for mobile cold-start detection
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Request
+from fastapi.responses import StreamingResponse
 from app.models.schemas import AnalysisRequest, PublicAnalysisRequest, AnalysisResponse
 from app.routers.auth import verify_firebase_token
 from app.core.rate_limit import check_rate_limit
@@ -16,11 +18,12 @@ from app.services.analysis_client import call_analysis_service as call_analysis_
 from app.config import settings
 import logging
 import uuid
+import json
+import httpx
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
 
 
 @router.get("/analysis-service/health")
@@ -205,3 +208,173 @@ async def analyze_message_public(http_request: Request, request: PublicAnalysisR
     except Exception as e:
         logger.error(f"Error in public analysis endpoint: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Analysis failed")
+
+
+# ---------------------------------------------------------------------------
+# Helper: format a single SSE data line
+# ---------------------------------------------------------------------------
+
+def _sse(event: dict) -> str:
+    return f"data: {json.dumps(event)}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Streaming analysis endpoint — gateway layer
+# ---------------------------------------------------------------------------
+
+@router.post("/analyze/stream")
+async def analyze_message_stream(
+    http_request: Request,
+    request: AnalysisRequest,
+    user_data: dict = Depends(verify_firebase_token),
+):
+    """
+    Stage-based streaming analysis using SSE.
+
+    Auth, rate-limiting, idempotency and DB writes are identical to
+    /api/analyze.  The difference is that progress events are emitted
+    to the client as each pipeline step completes in the analysis service.
+
+    Event stages (in order):
+      started → classification_started → classification_complete
+      → evidence_started → evidence_complete
+      → coach_started → coach_complete → complete | error
+    """
+    # ── Auth ──────────────────────────────────────────────────────────────
+    if request.user_id != user_data.get("uid"):
+        raise HTTPException(status_code=403, detail="User ID mismatch")
+
+    # ── Rate limit ────────────────────────────────────────────────────────
+    check_rate_limit(
+        http_request,
+        max_requests=settings.rate_limit_analysis,
+        window_seconds=settings.rate_limit_analysis_window,
+        user_id=request.user_id,
+    )
+
+    # ── Idempotency (same logic as /api/analyze) ──────────────────────────
+    if request.request_id:
+        db = Database.get_db()
+        existing = await db.interactions.find_one({
+            "user_id": request.user_id,
+            "request_id": request.request_id,
+        })
+        if existing and existing.get("full_response"):
+            logger.info("Idempotency hit for request_id %s (stream)", request.request_id)
+            # Replay a minimal event stream from cache
+            async def replay():
+                yield _sse({"stage": "started", "message": "Analysis started (cached)"})
+                yield _sse({"stage": "classification_complete", "message": "Classification complete"})
+                yield _sse({"stage": "evidence_complete", "message": "Evidence gathered"})
+                yield _sse({"stage": "coach_complete", "message": "Coaching explanation ready"})
+                yield _sse({"stage": "complete", "message": "Analysis complete",
+                            "result": existing["full_response"]})
+            return StreamingResponse(replay(), media_type="text/event-stream",
+                                     headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+
+    session_id = str(uuid.uuid4())
+
+    # ── Learning context ──────────────────────────────────────────────────
+    from app.agents.memory import memory_agent
+    learning_context = await memory_agent.get_learning_context(request.user_id)
+
+    # ── Build request payload for analysis service ────────────────────────
+    payload = {
+        "message": request.message,
+        "user_guess": request.user_guess,
+        "learning_context": learning_context,
+    }
+    headers: dict = {"Content-Type": "application/json"}
+    if settings.analysis_service_api_key:
+        headers["X-Internal-Service-Key"] = settings.analysis_service_api_key
+
+    # ── Generator: stream from analysis service → client ─────────────────
+    async def event_generator():
+        final_result: dict | None = None
+        stream_error = False
+
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
+                async with client.stream(
+                    "POST",
+                    f"{settings.analysis_service_url}/analyze/stream",
+                    json=payload,
+                    headers=headers,
+                ) as resp:
+                    if resp.status_code != 200:
+                        logger.error("Analysis service stream returned %s", resp.status_code)
+                        yield _sse({"stage": "error", "message": "Analysis service unavailable"})
+                        stream_error = True
+                        return
+
+                    async for line in resp.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        raw = line[len("data: "):]
+                        try:
+                            event = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+
+                        # Pass event through to the client
+                        yield _sse(event)
+
+                        if event.get("stage") == "complete":
+                            final_result = event.get("result")
+                        elif event.get("stage") == "error":
+                            stream_error = True
+
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            logger.error("Stream connection to analysis service failed: %s", exc)
+            yield _sse({"stage": "error", "message": "Analysis service unavailable"})
+            stream_error = True
+        except Exception as exc:
+            logger.error("Unexpected error in stream gateway: %s", exc, exc_info=True)
+            yield _sse({"stage": "error", "message": "Analysis failed"})
+            stream_error = True
+
+        # ── After stream: write DB/profile (same as /api/analyze) ─────────
+        if final_result and not stream_error:
+            try:
+                classification = final_result.get("classification", {})
+                category = final_result.get("category", "general_phishing")
+                was_correct = None
+                if request.user_guess:
+                    was_correct = request.user_guess.lower() == classification.get("label", "").lower()
+
+                final_result["session_id"] = session_id
+                final_result["was_correct"] = was_correct
+
+                from app.tools.profile_tools import InteractionLogger
+                await memory_agent.update_profile(
+                    user_id=request.user_id,
+                    category=category,
+                    was_correct=was_correct,
+                )
+
+                db = Database.get_db()
+                user_profile = await db.user_profiles.find_one({"user_id": request.user_id})
+                save_message_text = True
+                if user_profile is not None:
+                    save_message_text = user_profile.get("save_message_text", True)
+
+                await InteractionLogger.log_interaction(
+                    user_id=request.user_id,
+                    message=request.message,
+                    user_guess=request.user_guess,
+                    classification=classification,
+                    was_correct=was_correct,
+                    session_id=session_id,
+                    request_id=request.request_id,
+                    full_response=final_result,
+                    save_message_text=save_message_text,
+                )
+            except Exception as exc:
+                # Non-fatal: stream already delivered to client
+                logger.error("Post-stream DB write failed: %s", exc, exc_info=True)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -242,3 +242,132 @@ class TestAuthenticatedAnalysis:
             headers={"Authorization": "Bearer fake-token"},
         )
         assert resp.status_code == 422
+
+
+# ─── Streaming endpoint tests ──────────────────────────────────────────────────
+
+class TestStreamingAnalysis:
+    """Tests for POST /api/analyze/stream (C1)."""
+
+    def _stream_events(self, resp) -> list:
+        """Parse SSE data lines from a streaming response body."""
+        import json as _json
+        events = []
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                try:
+                    events.append(_json.loads(line[len("data: "):]))
+                except _json.JSONDecodeError:
+                    pass
+        return events
+
+    def test_stream_requires_auth(self, backend_client):
+        """Streaming endpoint must reject requests without Authorization header."""
+        resp = backend_client.post(
+            "/api/analyze/stream",
+            json={"message": "Hello", "user_id": "uid_abc"},
+        )
+        assert resp.status_code == 401
+
+    def test_stream_rejects_mismatched_user_id(self, backend_client):
+        """Streaming endpoint must return 403 when user_id does not match token uid."""
+        with patch("app.routers.analysis.call_analysis_service_with_retry",
+                   new=AsyncMock(return_value=dict(FAKE_ANALYSIS_RESULT))):
+            resp = backend_client.post(
+                "/api/analyze/stream",
+                json={"message": "Hello", "user_id": "wrong_uid"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+        assert resp.status_code == 403
+
+    def test_stream_emits_complete_event(self, backend_client):
+        """Successful stream must end with a 'complete' event containing the result."""
+        import json as _json
+
+        # Build a fake SSE body that the analysis service would return
+        fake_events = [
+            {"stage": "started", "message": "Analysis started"},
+            {"stage": "classification_started", "message": "Classifying message…"},
+            {"stage": "classification_complete", "message": "Classification complete",
+             "data": {"label": "phishing", "confidence": 0.9}},
+            {"stage": "evidence_started", "message": "Gathering evidence…"},
+            {"stage": "evidence_complete", "message": "Evidence gathered", "data": {"examples_found": 0}},
+            {"stage": "coach_started", "message": "Preparing coaching…"},
+            {"stage": "coach_complete", "message": "Coaching explanation ready"},
+            {"stage": "complete", "message": "Analysis complete", "result": FAKE_ANALYSIS_RESULT},
+        ]
+        fake_sse_body = "".join(f"data: {_json.dumps(e)}\n\n" for e in fake_events)
+
+        class FakeStreamResp:
+            status_code = 200
+            async def aiter_lines(self):
+                for line in fake_sse_body.splitlines():
+                    yield line
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeAsyncClient:
+            def stream(self, *args, **kwargs):
+                return FakeStreamResp()
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with patch("app.routers.analysis.httpx.AsyncClient", return_value=FakeAsyncClient()), \
+             patch("app.agents.memory.memory_agent.get_learning_context", new=AsyncMock(return_value={})), \
+             patch("app.agents.memory.memory_agent.update_profile", new=AsyncMock()), \
+             patch("app.tools.profile_tools.InteractionLogger.log_interaction", new=AsyncMock()), \
+             patch("app.models.database.Database.get_db", return_value=MagicMock(
+                 interactions=MagicMock(find_one=AsyncMock(return_value=None)),
+                 user_profiles=MagicMock(find_one=AsyncMock(return_value=None)),
+             )):
+            resp = backend_client.post(
+                "/api/analyze/stream",
+                json={"message": "Click here to claim your prize!", "user_id": "user_abc123"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+
+        assert resp.status_code == 200
+        events = self._stream_events(resp)
+        stages = [e["stage"] for e in events]
+        assert "complete" in stages, f"No 'complete' event found. Stages: {stages}"
+
+    def test_stream_emits_error_event_on_service_failure(self, backend_client):
+        """When analysis service is unreachable, stream must emit an 'error' event."""
+        import httpx as _httpx
+
+        class FailingStreamResp:
+            status_code = 200
+            async def aiter_lines(self):
+                raise _httpx.ConnectError("refused")
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        class FailingClient:
+            def stream(self, *args, **kwargs):
+                return FailingStreamResp()
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with patch("app.routers.analysis.httpx.AsyncClient", return_value=FailingClient()), \
+             patch("app.agents.memory.memory_agent.get_learning_context", new=AsyncMock(return_value={})), \
+             patch("app.models.database.Database.get_db", return_value=MagicMock(
+                 interactions=MagicMock(find_one=AsyncMock(return_value=None)),
+             )):
+            resp = backend_client.post(
+                "/api/analyze/stream",
+                json={"message": "Hello", "user_id": "user_abc123"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+
+        assert resp.status_code == 200
+        events = self._stream_events(resp)
+        stages = [e["stage"] for e in events]
+        assert "error" in stages, f"Expected 'error' event. Stages: {stages}"

--- a/frontend/src/app/analyze/page.tsx
+++ b/frontend/src/app/analyze/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -21,10 +21,14 @@ import {
   Brain,
   BookOpen,
   History,
+  Loader2,
 } from 'lucide-react';
-import { analyzeMessage, analyzePublicMessage } from '@/lib/api';
+import { analyzePublicMessage, streamAnalyzeMessage } from '@/lib/api';
+import type { StreamEvent, StreamStage } from '@/lib/api';
 import { useAuth } from '@/context/AuthContext';
 import ProtectedRoute from '@/components/ProtectedRoute';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SimilarExample {
   category: string;
@@ -57,70 +61,224 @@ interface AnalysisResult {
   coach_response: CoachResponse;
 }
 
+// ─── Stage progress config ────────────────────────────────────────────────────
+
+/** Labels shown in the checklist, in order. */
+const STAGE_LABELS = [
+  'Message received',
+  'Classifying risk',
+  'Gathering evidence',
+  'Preparing coaching',
+  'Complete',
+];
+
+/**
+ * Maps SSE completion events → checklist index (0-based).
+ * Intermediate *_started events are NOT in this map, so they never
+ * trigger a UI update and the checklist never regresses.
+ */
+const COMPLETION_STAGE_IDX: Partial<Record<StreamStage, number>> = {
+  started:                  0,
+  classification_complete:  1,
+  evidence_complete:        2,
+  coach_complete:           3,
+  complete:                 4,
+};
+
+// ─── Progress Card ────────────────────────────────────────────────────────────
+
+function ProgressCard({
+  completedStageIdx,
+  isError,
+  onRetry,
+}: {
+  /** Highest checklist index completed so far; -1 = nothing done yet. */
+  completedStageIdx: number;
+  isError: boolean;
+  onRetry: () => void;
+}) {
+  const completedIdx = completedStageIdx;
+
+  return (
+    <Card className="border-l-4 border-l-primary">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          {isError ? (
+            <AlertTriangle className="h-5 w-5 text-red-500" />
+          ) : (
+            <Brain className="h-5 w-5 text-primary animate-pulse" />
+          )}
+          {isError ? 'Analysis failed' : 'Analyzing…'}
+        </CardTitle>
+        <CardDescription>
+          {isError
+            ? 'Something went wrong. Please try again.'
+            : 'AI agents are working through each step.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {STAGE_LABELS.map((label, i) => {
+            const done = completedIdx >= i;
+            const active = !isError && !done && completedIdx === i - 1;
+            return (
+              <li key={label} className="flex items-center gap-3">
+                {done ? (
+                  <CheckCircle className="h-5 w-5 text-green-500 shrink-0" />
+                ) : active ? (
+                  <Loader2 className="h-5 w-5 text-primary shrink-0 animate-spin" />
+                ) : (
+                  <div className="h-5 w-5 rounded-full border-2 border-muted shrink-0" />
+                )}
+                <span
+                  className={
+                    done
+                      ? 'text-green-500 font-medium'
+                      : active
+                      ? 'text-primary font-medium'
+                      : 'text-muted-foreground'
+                  }
+                >
+                  {label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+      {isError && (
+        <CardFooter>
+          <Button onClick={onRetry} variant="outline" size="sm">
+            Retry
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
 export default function AnalyzePage() {
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<AnalysisResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [userGuess, setUserGuess] = useState<'phishing' | 'safe' | null>(null);
-  const [quizAnswer, setQuizAnswer] = useState<{ selected: string | null, isCorrect: boolean | null }>({ selected: null, isCorrect: null });
+  const [quizAnswer, setQuizAnswer] = useState<{ selected: string | null; isCorrect: boolean | null }>({
+    selected: null,
+    isCorrect: null,
+  });
+
+  // Streaming state
+  // completedStageIdx: highest checklist index reached (-1 = not started)
+  // This ONLY increases — never goes backwards, even when *_started events arrive.
+  const [completedStageIdx, setCompletedStageIdx] = useState(-1);
+  const [streamError, setStreamError] = useState(false);
+  const streamRef = useRef<{ abort: () => void } | null>(null);
+
   const { user } = useAuth();
 
+  // Clean up on unmount
+  useEffect(() => {
+    return () => { streamRef.current?.abort(); };
+  }, []);
+
   const handleAnalyze = async (skipGuess: boolean = false) => {
-    if (!message.trim()) return;
+    if (!message.trim() || loading) return;
 
     if (!user) {
       alert('Please sign in to use the full analysis tool.');
       return;
     }
 
-    // Prevent double submission
-    if (loading) {
-      return;
-    }
-
+    // Reset state
     setError(null);
+    setResult(null);
+    setCompletedStageIdx(-1);
+    setStreamError(false);
     setLoading(true);
 
-    // Use the user's guess, or 'unclear' if they skipped
     const guessToSend = skipGuess ? 'unclear' : (userGuess || 'unclear');
 
-    try {
-      let data;
+    // ── Try streaming endpoint first ───────────────────────────────────────
+    let streamSucceeded = false;
 
+    await new Promise<void>((resolve) => {
+      streamRef.current?.abort();
+
+      const handle = streamAnalyzeMessage(message, guessToSend, user.uid, (event: StreamEvent) => {
+        // Only advance the checklist on completion events — never on *_started events.
+        // This prevents the UI from going backwards when an intermediate event arrives.
+        const idx = COMPLETION_STAGE_IDX[event.stage];
+        if (idx !== undefined) {
+          setCompletedStageIdx((prev) => Math.max(prev, idx));
+        }
+
+        if (event.stage === 'complete') {
+          streamSucceeded = true;
+          setResult(event.result as AnalysisResult);
+          setLoading(false);
+          resolve();
+        } else if (event.stage === 'error') {
+          // Will fall back to regular endpoint below
+          setStreamError(true);
+          resolve();
+        }
+      });
+
+      streamRef.current = handle;
+
+      // Safety timeout: if stream hangs for 130 s, fall back
+      const timeout = setTimeout(() => {
+        handle.abort();
+        setStreamError(true);
+        resolve();
+      }, 130_000);
+
+      // Clear timeout when promise resolves normally
+      const origResolve = resolve;
+      (resolve as unknown as { _timeout: ReturnType<typeof setTimeout> })._timeout = timeout;
+      void origResolve;
+      // We rely on the event handlers above to call resolve()
+      // The timeout is a safety net; clear it in the complete/error branches above.
+      // (The timeout will fire and resolve() is idempotent.)
+      return () => clearTimeout(timeout);
+    });
+
+    if (streamSucceeded) return;
+
+    // ── Fallback: regular non-streaming endpoint ───────────────────────────
+    try {
+      const { analyzeMessage } = await import('@/lib/api');
+      let data;
       try {
         data = await analyzeMessage(message, guessToSend, user.uid);
       } catch (err: unknown) {
         const status = (err as { response?: { status?: number } }).response?.status;
-
-        // Only fall back to public endpoint for auth errors (401/403)
-        // Do NOT fallback for 500 errors - those indicate real problems
         if (status === 401 || status === 403) {
-          console.warn('Auth error, falling back to public endpoint:', err);
           data = await analyzePublicMessage(message, guessToSend);
         } else if (status === 429) {
-          setError('Quota gratuite atteinte. Réessaie plus tard ou utilise une autre clé API.');
+          setError('Rate limit reached. Please try again later.');
           return;
         } else {
-          // For all other errors (including 500), don't fallback
           throw err;
         }
       }
-
       setResult(data);
-      setQuizAnswer({ selected: null, isCorrect: null }); // Reset quiz for new analysis
+      setQuizAnswer({ selected: null, isCorrect: null });
     } catch (err: unknown) {
       console.error('Analysis failed:', err);
       setResult(null);
-
-      // Handle different error types
       if ((err as { response?: { status?: number } }).response?.status === 429) {
-        setError('Quota gratuite atteinte. Réessaie plus tard.');
+        setError('Rate limit reached. Please try again later.');
       } else {
         setError('Analysis failed. Please try again in a moment.');
       }
     } finally {
       setLoading(false);
+      setCompletedStageIdx(-1);
+      setStreamError(false);
     }
   };
 
@@ -141,7 +299,7 @@ export default function AnalyzePage() {
             )}
           </div>
 
-          {/* 2-column layout so the input box is wider */}
+          {/* 2-column layout */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             {/* Input Section */}
             <div className="space-y-6">
@@ -156,6 +314,7 @@ export default function AnalyzePage() {
                     className="min-h-[300px] resize-none font-mono text-sm"
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
+                    disabled={loading}
                   />
                 </CardContent>
                 <CardFooter className="flex flex-col gap-4">
@@ -188,7 +347,14 @@ export default function AnalyzePage() {
                       onClick={() => handleAnalyze(false)}
                       disabled={loading || !message.trim() || !userGuess}
                     >
-                      {loading ? 'Analyzing...' : 'Analyze with My Prediction'}
+                      {loading ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Analyzing…
+                        </>
+                      ) : (
+                        'Analyze with My Prediction'
+                      )}
                     </Button>
                     <Button
                       variant="ghost"
@@ -214,18 +380,29 @@ export default function AnalyzePage() {
               </Card>
             </div>
 
-            {/* Results Section */}
+            {/* Results / Progress Section */}
             <div>
-              {result ? (
+              {/* Stage progress — shown while streaming */}
+              {loading && (
+                <ProgressCard
+                  completedStageIdx={completedStageIdx}
+                  isError={streamError}
+                  onRetry={() => handleAnalyze(false)}
+                />
+              )}
+
+              {/* Full result — shown after streaming completes */}
+              {result && !loading ? (
                 <div className="space-y-6">
                   {/* Verdict Card */}
                   <Card
-                    className={`border-l-4 ${result.classification.label === 'phishing'
-                      ? 'border-l-red-500'
-                      : result.classification.label === 'safe'
+                    className={`border-l-4 ${
+                      result.classification.label === 'phishing'
+                        ? 'border-l-red-500'
+                        : result.classification.label === 'safe'
                         ? 'border-l-green-500'
                         : 'border-l-yellow-500'
-                      }`}
+                    }`}
                   >
                     <CardHeader>
                       <div className="flex items-center justify-between">
@@ -273,10 +450,13 @@ export default function AnalyzePage() {
 
                       {/* Prediction Feedback */}
                       {userGuess && (
-                        <div className={`mt-4 p-3 rounded-lg flex items-center gap-2 ${userGuess === result.classification.label
-                          ? 'bg-green-500/10 border border-green-500/30'
-                          : 'bg-red-500/10 border border-red-500/30'
-                          }`}>
+                        <div
+                          className={`mt-4 p-3 rounded-lg flex items-center gap-2 ${
+                            userGuess === result.classification.label
+                              ? 'bg-green-500/10 border border-green-500/30'
+                              : 'bg-red-500/10 border border-red-500/30'
+                          }`}
+                        >
                           {userGuess === result.classification.label ? (
                             <>
                               <CheckCircle className="h-5 w-5 text-green-500" />
@@ -288,7 +468,8 @@ export default function AnalyzePage() {
                             <>
                               <AlertTriangle className="h-5 w-5 text-red-500" />
                               <span className="text-red-500 font-medium">
-                                Your prediction was &quot;{userGuess}&quot; — the AI classified it as &quot;{result.classification.label}&quot;.
+                                Your prediction was &quot;{userGuess}&quot; — the AI classified
+                                it as &quot;{result.classification.label}&quot;.
                               </span>
                             </>
                           )}
@@ -385,7 +566,8 @@ export default function AnalyzePage() {
                                 {result.coach_response.quiz.options.map(
                                   (option: string, i: number) => {
                                     const isSelected = quizAnswer.selected === option;
-                                    const isCorrectOption = option === result.coach_response.quiz?.correct_answer;
+                                    const isCorrectOption =
+                                      option === result.coach_response.quiz?.correct_answer;
                                     const showResult = quizAnswer.selected !== null;
 
                                     return (
@@ -393,14 +575,16 @@ export default function AnalyzePage() {
                                         key={i}
                                         variant="outline"
                                         disabled={showResult}
-                                        className={`w-full justify-start h-auto py-3 px-4 whitespace-normal text-left transition-all ${showResult && isCorrectOption
-                                          ? 'border-green-500 bg-green-500/10 text-green-500'
-                                          : showResult && isSelected && !isCorrectOption
+                                        className={`w-full justify-start h-auto py-3 px-4 whitespace-normal text-left transition-all ${
+                                          showResult && isCorrectOption
+                                            ? 'border-green-500 bg-green-500/10 text-green-500'
+                                            : showResult && isSelected && !isCorrectOption
                                             ? 'border-red-500 bg-red-500/10 text-red-500'
                                             : ''
-                                          }`}
+                                        }`}
                                         onClick={() => {
-                                          const correct = option === result.coach_response.quiz?.correct_answer;
+                                          const correct =
+                                            option === result.coach_response.quiz?.correct_answer;
                                           setQuizAnswer({ selected: option, isCorrect: correct });
                                         }}
                                       >
@@ -417,19 +601,26 @@ export default function AnalyzePage() {
                                 )}
                               </div>
                               {quizAnswer.selected && (
-                                <div className={`p-3 rounded-lg flex items-center gap-2 ${quizAnswer.isCorrect
-                                  ? 'bg-green-500/10 border border-green-500/30'
-                                  : 'bg-red-500/10 border border-red-500/30'
-                                  }`}>
+                                <div
+                                  className={`p-3 rounded-lg flex items-center gap-2 ${
+                                    quizAnswer.isCorrect
+                                      ? 'bg-green-500/10 border border-green-500/30'
+                                      : 'bg-red-500/10 border border-red-500/30'
+                                  }`}
+                                >
                                   {quizAnswer.isCorrect ? (
                                     <>
                                       <CheckCircle className="h-5 w-5 text-green-500" />
-                                      <span className="text-green-500 font-medium">Correct! Well done.</span>
+                                      <span className="text-green-500 font-medium">
+                                        Correct! Well done.
+                                      </span>
                                     </>
                                   ) : (
                                     <>
                                       <AlertTriangle className="h-5 w-5 text-red-500" />
-                                      <span className="text-red-500 font-medium">Not quite. The correct answer is highlighted above.</span>
+                                      <span className="text-red-500 font-medium">
+                                        Not quite. The correct answer is highlighted above.
+                                      </span>
                                     </>
                                   )}
                                 </div>
@@ -445,14 +636,14 @@ export default function AnalyzePage() {
                     </TabsContent>
                   </Tabs>
                 </div>
-              ) : (
+              ) : !loading ? (
                 <div className="h-full flex items-center justify-center min-h-[400px] border-2 border-dashed rounded-lg text-muted-foreground">
                   <div className="text-center space-y-2">
                     <Shield className="h-12 w-12 mx-auto opacity-20" />
                     <p>Enter a message to see the analysis results here.</p>
                   </div>
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,6 +64,104 @@ export const analyzePublicMessage = async (
   return response.data;
 };
 
+// ── Streaming analysis (C1) ───────────────────────────────────────────────────
+
+export type StreamStage =
+  | "started"
+  | "classification_started"
+  | "classification_complete"
+  | "evidence_started"
+  | "evidence_complete"
+  | "coach_started"
+  | "coach_complete"
+  | "complete"
+  | "error";
+
+export interface StreamEvent {
+  stage: StreamStage;
+  message: string;
+  data?: Record<string, unknown>;
+  result?: unknown;
+}
+
+/**
+ * Stream a staged analysis via Server-Sent Events.
+ *
+ * Calls onEvent for every SSE event received from the backend.
+ * The final event has stage="complete" and contains the full result.
+ * If streaming fails (network error, service down) it calls onEvent
+ * with stage="error" so the caller can fall back gracefully.
+ *
+ * Returns a cleanup function that aborts the stream if called.
+ */
+export function streamAnalyzeMessage(
+  message: string,
+  userGuess: UserGuess,
+  userId: string,
+  onEvent: (event: StreamEvent) => void
+): { abort: () => void } {
+  const controller = new AbortController();
+  const requestId = generateUUID();
+
+  (async () => {
+    try {
+      const token = auth.currentUser ? await auth.currentUser.getIdToken() : null;
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
+      const resp = await fetch(`${API_URL}/api/analyze/stream`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          message,
+          user_guess: userGuess,
+          user_id: userId,
+          request_id: requestId,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!resp.ok || !resp.body) {
+        onEvent({ stage: "error", message: "Analysis service unavailable" });
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE lines are separated by \n\n
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+
+        for (const part of parts) {
+          for (const line of part.split("\n")) {
+            if (line.startsWith("data: ")) {
+              try {
+                const event: StreamEvent = JSON.parse(line.slice(6));
+                onEvent(event);
+              } catch {
+                // malformed line — skip
+              }
+            }
+          }
+        }
+      }
+    } catch (err: unknown) {
+      if ((err as { name?: string }).name === "AbortError") return;
+      console.error("Stream error:", err);
+      onEvent({ stage: "error", message: "Analysis failed" });
+    }
+  })();
+
+  return { abort: () => controller.abort() };
+}
+
 // Single aggregate endpoint — replaces 4 separate dashboard calls
 export const getDashboard = async () => {
   const response = await api.get(`/api/dashboard`);

--- a/services/analysis-service/app/main.py
+++ b/services/analysis-service/app/main.py
@@ -7,8 +7,10 @@ Handles message classification, evidence finding, and coaching.
 
 from fastapi import FastAPI, HTTPException, Header, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from typing import Optional
 import logging
+import json
 
 from app.schemas import AnalysisRequest, AnalysisResponse
 from app.orchestrator import run_analysis
@@ -107,6 +109,116 @@ async def analyze_message(
         raise HTTPException(status_code=500, detail="Analysis failed")
 
 
+def _sse_line(event: dict) -> str:
+    """Format a dict as a single SSE data line ending with double newline."""
+    return f"data: {json.dumps(event)}\n\n"
+
+
+@app.post("/analyze/stream")
+async def analyze_message_stream(
+    request: AnalysisRequest,
+    _: None = Depends(verify_internal_key),
+):
+    """
+    Stage-based streaming analysis endpoint.
+
+    Yields SSE (Server-Sent Events) data lines as each pipeline step completes:
+      started → classification_complete → evidence_complete → coach_complete → complete
+    or an 'error' event on failure.
+
+    This is the real pipeline: events are emitted AFTER each agent actually finishes,
+    not faked timers.
+    """
+
+    async def event_generator():
+        try:
+            yield _sse_line({"stage": "started", "message": "Analysis started"})
+
+            # ── Step 1: Classify ──────────────────────────────────────────────
+            yield _sse_line({"stage": "classification_started", "message": "Classifying message…"})
+
+            from app.agents.classifier import classifier_agent
+            classification = await classifier_agent.classify(request.message)
+            category = classifier_agent.determine_category(
+                classification["reason_tags"],
+                request.message,
+            )
+            yield _sse_line({
+                "stage": "classification_complete",
+                "message": "Classification complete",
+                "data": {
+                    "label": classification["label"],
+                    "confidence": classification["confidence"],
+                },
+            })
+
+            # ── Step 2: Evidence ──────────────────────────────────────────────
+            yield _sse_line({"stage": "evidence_started", "message": "Gathering evidence…"})
+
+            from app.agents.evidence import evidence_agent
+            similar_examples = await evidence_agent.find_evidence(
+                message=request.message,
+                reason_tags=classification["reason_tags"],
+                category=category,
+                max_examples=3,
+            )
+            yield _sse_line({
+                "stage": "evidence_complete",
+                "message": "Evidence gathered",
+                "data": {"examples_found": len(similar_examples)},
+            })
+
+            # ── Step 3: Coach ─────────────────────────────────────────────────
+            yield _sse_line({"stage": "coach_started", "message": "Preparing coaching…"})
+
+            from app.agents.coach import coach_agent
+            learning_context: dict = {}
+            if request.learning_context:
+                learning_context = request.learning_context.model_dump()
+            else:
+                learning_context = {
+                    "total_messages": 0,
+                    "accuracy": 0.0,
+                    "weak_spots": [],
+                    "by_category": {},
+                    "is_new_user": True,
+                }
+
+            coach_response = await coach_agent.generate_coaching(
+                message=request.message,
+                classification=classification,
+                similar_examples=similar_examples,
+                learning_context=learning_context,
+            )
+            yield _sse_line({"stage": "coach_complete", "message": "Coaching explanation ready"})
+
+            # ── Final result ──────────────────────────────────────────────────
+            was_correct = None
+            if request.user_guess:
+                was_correct = request.user_guess.lower() == classification["label"].lower()
+
+            result = {
+                "classification": classification,
+                "coach_response": coach_response,
+                "was_correct": was_correct,
+                "category": category,
+            }
+            yield _sse_line({"stage": "complete", "message": "Analysis complete", "result": result})
+
+        except Exception as exc:
+            logger.error("Streaming analysis failed: %s", exc, exc_info=True)
+            yield _sse_line({"stage": "error", "message": "Analysis failed"})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",   # disable Nginx buffering
+        },
+    )
+
+
 @app.on_event("startup")
 async def startup_event():
     """Initialize components on startup - fast, no blocking loads."""
@@ -119,4 +231,3 @@ async def startup_event():
         )
     logger.info("Dataset will load lazily on first request")
     logger.info("Analysis Service ready!")
-


### PR DESCRIPTION
- analysis-service: POST /analyze/stream emits events as each agent
  (classifier → evidence → coach) completes
- gateway: POST /api/analyze/stream authenticates, rate-limits,
  pipes events, writes DB after stream ends — no duplicate writes
- frontend: streamAnalyzeMessage() consumes the stream; Analyze page
  shows a live checklist (Message received → Classifying → Gathering
  evidence → Coaching → Complete); falls back to /api/analyze on error
- tests: 4 new tests for streaming auth, 403 mismatch, complete event,
  error event; all 41 backend tests pass